### PR TITLE
Add `yo` to `peerDeps`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Just the basics: [Node.js](http://nodejs.org/) and npm, [Ruby](http://www.ruby-l
 
 ## Quick start
 
-- Install the Yeoman tools: `npm install -g yo grunt-cli bower`
 - Install the generator: `npm install -g generator-jekyllrb`
 - Run: `yo jekyllrb`
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "shelljs": "~0.1.4"
   },
   "peerDependencies": {
-    "generator-mocha": "~0.1.1"
+    "generator-mocha": "~0.1.1",
+    "yo": ">=1.0.0-rc.1.1"
   },
   "devDependencies": {
     "mocha": "~1.9.0"


### PR DESCRIPTION
Automatically installs `yo` together with `grunt-cli` and `bower` when installing the generator.
