### PR TITLE
Fix bower's relative path to absolute path in H5BP template

### DIFF
--- a/app/templates/conditional/template-H5BP/_includes/scripts.html
+++ b/app/templates/conditional/template-H5BP/_includes/scripts.html
@@ -1,6 +1,6 @@
 <% if (h5bpJs) { %><script src="//ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min.js"></script>
 
-<script>window.jQuery || document.write('<script src="_bower_components/jquery.min.js"><\/script>')</script>
+<script>window.jQuery || document.write('<script src="/_bower_components/jquery.min.js"><\/script>')</script>
 <% } %><!-- build:js<% if (jsPre) { %>({app,.tmp})<% } else { %>(app)<% } %> /<%= jsDir %>/script.js --><% if (h5bpJs) { %>
 <script src="/<%= jsDir %>/plugins.js"></script><% } %>
 <script src="/<%= jsDir %>/main.js"></script>

--- a/app/templates/conditional/template-H5BP/_layouts/default.html
+++ b/app/templates/conditional/template-H5BP/_layouts/default.html
@@ -20,7 +20,7 @@
 
     <!-- build:js<% if (jsPre) { %>({app,.tmp})<% } else { %>(app)<% } %> /<%= jsDir %>/head-scripts.js -->
     <!-- Replace with a custom modernizer build for production -->
-    <script src="_bower_components/modernizr/modernizr.js"></script><% } %>
+    <script src="/_bower_components/modernizr/modernizr.js"></script><% } %>
     <!-- endbuild -->
 
   </head>


### PR DESCRIPTION
Fix a following problem.
# Expected

``` bash
$ yo jekyllrb
# * Select H5BP template
# * And select 'Add H5★BP javascript files?' to YES
# * And select 'Choose a post permalink style' to pretty

$ grunt server

# Open Chrome web browser
$ open http://localhost:9000/jekyll/update/2013/09/02/yo-jekyllrb/
# Open JavaScript Console
(CTRL-SHIFT-J in Chrome)
```

There are **no errors in JavaScript Console**. 
# Actual

Same as above, and...

There is **an error in JavaScript Console**. 

![generator-jekyllrb_fix-bower](https://f.cloud.github.com/assets/20859/1064184/ce8c9488-1317-11e3-8262-4bef43510e9c.png)
