### PR TITLE
Livereload permissions error on Windows

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -51,10 +51,13 @@ module.exports = function (grunt) {
           livereload: '<%%= connect.options.livereload %>'
         },
         files: [
-          '.jekyll/**/*.html',<% if (autoPre) { %>
+          // '.jekyll/**/*.html',
+          <% if (autoPre) { %>
           '.tmp/<%= cssDir %>/**/*.css',<% } else { %>
           '{.tmp,<%%= yeoman.app %>}/<%= cssDir %>/**/*.css',<% } %>
           '{.tmp,<%%= yeoman.app %>}/<%%= js %>/**/*.js',
+          '<%= yeoman.app %>/<%= posts %>/**/*.md',
+          '<%= yeoman.app %>/**/*.html',
           '<%%= yeoman.app %>/<%= imgDir %>/**/*.{gif,jpg,jpeg,png,svg,webp}'
         ]
       }


### PR DESCRIPTION
My first ever pull request, hope I've done it right :-)

Gruntfile was creating an issue with livereload resulting in a permissions error on windows machines - see issue #30 - seems to be an infinite loop. Livereload watched for html files in the .jekyll folder. This was changed to watch changes to posts - .md files - and the layout and index html files. This fixed the issue for me and allowed livereload updates to continue.
