### PR TITLE
Fix README to read 'grunt deploy' from 'grunt build'

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Builds an optimized site to the dist directory. [Usemin blocks](https://github.c
 
 #### grunt deploy
 
-During scaffolding the generator gives you the option to configure [grunt-build-control](https://github.com/robwierzbowski/grunt-build-control) to version and deploy your built code to a remote repository. If you configure build-control, `grunt build` will run `grunt check`, `grunt test`, `grunt build`, and then commit and deploy your built code to the specified remote repository. 
+During scaffolding the generator gives you the option to configure [grunt-build-control](https://github.com/robwierzbowski/grunt-build-control) to version and deploy your built code to a remote repository. If you configure build-control, `grunt deploy` will run `grunt check`, `grunt test`, `grunt build`, and then commit and deploy your built code to the specified remote repository. 
 
 #### grunt (default)
 


### PR DESCRIPTION
Fix typo in the readme.
