### PR TITLE
Fix LiveReload for asset subdirectories. Fixes #56.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -168,6 +168,18 @@ Generator.prototype.askForStructure = function askForStructure() {
     this.cssPreDir = props.cssPreDir;
     this.jsPreDir  = props.jsPreDir;
 
+    // Split asset directories on slashes
+    var cssParts   = props.cssDir.split('/');
+    var jsParts    = props.jsDir.split('/');
+    var imgParts   = props.imgDir.split('/');
+    var fontsParts = props.fontsDir.split('/');
+
+    // Build Jekyll exclude directories
+    this.cssExDir   = cssParts[cssParts.length - 1];
+    this.jsExDir    = jsParts[jsParts.length - 1];
+    this.imgExDir   = imgParts[imgParts.length - 1];
+    this.fontsExDir = fontsParts[fontsParts.length - 1];
+
     cb();
   }.bind(this));
 };

--- a/app/templates/_config.yml
+++ b/app/templates/_config.yml
@@ -10,7 +10,7 @@ author:
   email: <%= email %>
 
 # Grunt handles images and assets.
-exclude: ['<%= imgDir %>', '<%= cssDir %>', '<%= jsDir %>', '<%= fontsDir %>',
+exclude: ['<%= imgExDir %>', '<%= cssExDir %>', '<%= jsExDir %>', '<%= fontsExDir %>',
           '**.png', '**.jpg', '**.jpeg', '**.gif', '**.webp', '**.svg', '**.ico']
 
 include: ['.htaccess']


### PR DESCRIPTION
Jekyll's `_config.yml` exclude option does not allow for paths to subdirectories. In order to support LiveReload of asset subdirectories, this commit passes the `_config.yml` file the deepest directory for each asset type (e.g. – JavaScript, CSS, images, fonts). Fixes #56.
