### PR TITLE
Removed running Sass files through csslint

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -381,7 +381,6 @@ module.exports = function (grunt) {
       check: {
         src: [
           '<%%= yeoman.app %>/<%= cssDir %>/**/*.css',
-          '<%%= yeoman.app %>/<%= cssPreDir %>/**/*.scss'
         ]
       }
     },


### PR DESCRIPTION
Running csslint on Sass files throws errors. I think csslint should only be run on the generated CSS files. I'm using SCSS syntax, btw.
