### PR TITLE
Vote to move imagemin

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -439,7 +439,6 @@ module.exports = function (grunt) {
     'autoprefixer:dist',<% } %>
     'cssmin',
     'uglify',
-    'imagemin',
     'svgmin',
     'filerev',
     'usemin',
@@ -450,6 +449,7 @@ module.exports = function (grunt) {
     'check',
     'test',
     'build',
+    'imagemin',
     'buildcontrol'
     ]);<% } %>
 


### PR DESCRIPTION
I have moved the imagemin task to deploy. In my workflow imagemin was taking the most time (a site with 5 images, this task takes 7.1 seconds). Which becomes annoying when testing out changes quickly. I submit this for consideration. The imagemin task is pretty self contained, not manipulating filepaths only the files contents.
