### PR TITLE
Add rvm configuration files to gitignore

### DIFF
--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -37,3 +37,8 @@ app/_bower_components
 dist
 node_modules
 .tmp
+
+# Ignore for RVM users #
+.ruby-version
+.ruby-gemset
+.rvmrc


### PR DESCRIPTION
rvm users frequently use `.ruby-version`, `.ruby-gemset`, or `.rvmrc` (legacy) files to configure rvm and it's a Bad Practice™ to commit them. This will help prevent that for those folks.
