### PR TITLE
Run autoprefixer after cssmin

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -438,9 +438,9 @@ module.exports = function (grunt) {
     'jekyll:dist',
     'concurrent:dist',
     'useminPrepare',
-    'concat',<% if (autoPre) { %>
+    'concat',
+    'cssmin',<% if (autoPre) { %>
     'autoprefixer:dist',<% } %>
-    'cssmin',
     'uglify',
     'imagemin',
     'svgmin',


### PR DESCRIPTION
The autoprefixer task in the build task has to be after the cssmin one, because it's cssmin which moves files from .tmp/concat/css to dist/css:

```
Running "cssmin:generated" (cssmin) task
Verifying property cssmin.generated exists in config...OK
Files: .tmp/concat/css/vendor.css -> dist/css/vendor.css
Files: .tmp/concat/css/main.css -> dist/css/main.css
Options: report=false
Reading .tmp/concat/css/vendor.css...OK
Reading .tmp/concat/css/vendor.css...OK
Writing dist/css/vendor.css...OK
File dist/css/vendor.css created.
Reading .tmp/concat/css/main.css...OK
Reading .tmp/concat/css/main.css...OK
Writing dist/css/main.css...OK
File dist/css/main.css created.
```

The autoprefixer looks for files in the dist/css folder:

```
Running "autoprefixer:dist" (autoprefixer) task
Verifying property autoprefixer.dist exists in config...OK
Files: dist/css/main.css -> dist/css/main.css
Files: dist/css/vendor.css -> dist/css/vendor.css
Options: diff=false, map=false, browsers=["last 2 versions"]
Reading dist/css/main.css...OK
Writing dist/css/main.css...OK
File "dist/css/main.css" prefixed.
Reading dist/css/vendor.css...OK
Writing dist/css/vendor.css...OK
File "dist/css/vendor.css" prefixed.
```
