### PR TITLE
Fix gruntfile template so it builds

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -52,7 +52,7 @@ module.exports = function (grunt) {
           src: [
             '.jekyll/**/*.html',
             '.tmp/css/**/*.css',
-            '{.tmp,<%%= yeoman.app %>}/<%= js %>/**/*.js',
+            '{.tmp,<%%= yeoman.app %>}/<%= jsDir %>/**/*.js',
             '{<%%= yeoman.app %>}/_bower_components/**/*.js',
             '<%%= yeoman.app %>/img/**/*.{gif,jpg,jpeg,png,svg,webp}'
           ]
@@ -80,7 +80,7 @@ module.exports = function (grunt) {
           src: [
             '.jekyll/**/*.html',
             '.tmp/css/**/*.css',
-            '{.tmp,<%%= yeoman.app %>}/<%= js %>/**/*.js',
+            '{.tmp,<%%= yeoman.app %>}/<%= jsDir %>/**/*.js',
             '{<%%= yeoman.app %>}/_bower_components/**/*.js',
             '<%%= yeoman.app %>/img/**/*.{gif,jpg,jpeg,png,svg,webp}'
           ]

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -52,9 +52,9 @@ module.exports = function (grunt) {
           src: [
             '.jekyll/**/*.html',
             '.tmp/css/**/*.css',
-            '{.tmp,<%= yeoman.app %>}/<%= js %>/**/*.js',
-            '{<%= yeoman.app %>}/_bower_components/**/*.js',
-            '<%= yeoman.app %>/img/**/*.{gif,jpg,jpeg,png,svg,webp}'
+            '{.tmp,<%%= yeoman.app %>}/<%= js %>/**/*.js',
+            '{<%%= yeoman.app %>}/_bower_components/**/*.js',
+            '<%%= yeoman.app %>/img/**/*.{gif,jpg,jpeg,png,svg,webp}'
           ]
         },
         options: {
@@ -62,7 +62,7 @@ module.exports = function (grunt) {
             baseDir: [
               ".jekyll",
               ".tmp",
-              "<%= yeoman.app %>"
+              "<%%= yeoman.app %>"
             ]
           },
           watchTask: true
@@ -71,7 +71,7 @@ module.exports = function (grunt) {
       dist: {
         options: {
           server: {
-            baseDir: "<%= yeoman.dist %>"
+            baseDir: "<%%= yeoman.dist %>"
           }
         }
       },
@@ -80,9 +80,9 @@ module.exports = function (grunt) {
           src: [
             '.jekyll/**/*.html',
             '.tmp/css/**/*.css',
-            '{.tmp,<%= yeoman.app %>}/<%= js %>/**/*.js',
-            '{<%= yeoman.app %>}/_bower_components/**/*.js',
-            '<%= yeoman.app %>/img/**/*.{gif,jpg,jpeg,png,svg,webp}'
+            '{.tmp,<%%= yeoman.app %>}/<%= js %>/**/*.js',
+            '{<%%= yeoman.app %>}/_bower_components/**/*.js',
+            '<%%= yeoman.app %>/img/**/*.{gif,jpg,jpeg,png,svg,webp}'
           ]
         },
         options: {
@@ -90,7 +90,7 @@ module.exports = function (grunt) {
             baseDir: [
               ".jekyll",
               ".tmp",
-              "<%= yeoman.app %>"
+              "<%%= yeoman.app %>"
             ]
           },
           watchTask: true


### PR DESCRIPTION
This fixes the Gruntfile template so the Gruntfile can be built properly.

+ `<%= js %>` should be `<%= jsDir %>`
+ `<%= yeoman.app %>` and `<%= yeoman.dist %>` should be escaped; like `<%%= yeoman.app %>`