### PR TITLE
Generated Gemfile missing necessary line breaks

### DIFF
--- a/app/templates/Gemfile
+++ b/app/templates/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem 'jekyll', '~> 2.3.0'<% if (jekMkd) { %>
-gem '<%= jekMkd %>'<% } if (cssPre === 'sass') { %>
-gem 'sass', '~> 3.4.3'<% } if (cssPre === 'compass') { %>
-gem 'compass', '~> 1.0.1'<% } %>
+gem 'jekyll', '~> 2.3.0'
+<% if (jekMkd) { %>gem '<%= jekMkd %>'<% } %>
+<% if (cssPre === 'sass') { %>gem 'sass', '~> 3.4.3'<% } %>
+<% if (cssPre === 'compass') { %>gem 'compass', '~> 1.0.1'<% } %>


### PR DESCRIPTION
I keep running into the newline issue mentioned in #143.

This PR corrects the Gemfile template by breaking apart the conditionals, giving each its own line.
#### Generated Gemfile

Before (_current_):

``` ruby
source "http://rubygems.org"

gem 'jekyll', '~> 2.3.0'gem 'redcarpet'gem 'sass', '~> 3.4.3'
```

After:

``` ruby
source "http://rubygems.org"

gem 'jekyll', '~> 2.3.0'
gem 'redcarpet'
gem 'sass', '~> 3.4.3'
```
