### PR TITLE
Updates the fixed grunt-browser-sync version to 2.1.3, resolving #145

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -8,7 +8,7 @@
     "grunt": "~0.4.5",<% if (autoPre) { %>
     "grunt-autoprefixer": "~1.0.1",<% } %><% if (deploy) { %>
     "grunt-build-control": "~0.1.3",<% } %>
-    "grunt-browser-sync": "~1.3.6",
+    "grunt-browser-sync": "~2.1.3",
     "grunt-concurrent": "~0.5.0",
     "grunt-contrib-clean": "~0.6.0",<% if (jsPre === 'coffeescript') { %>
     "grunt-coffeelint": "~0.0.13",


### PR DESCRIPTION
I have run into the same issue mentioned in #145 and found that updating the template to use the latest version of `grunt-browser-sync`, version `2.1.3`, fixes this.

---

Running `grunt serve` on a freshly generated project...

Before:

```
Running "browserSync:server" (browserSync) task
Warning: Cannot read property 'prototype' of undefined Used --force, continuing.
```

After:

No errors. :octocat: 
